### PR TITLE
Rename conda environment references

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,16 +291,16 @@ Install with:
 ```
 - open a new terminal/shell, and conda should be available: `conda -v`.
 
-### Install DAYCLI Environment
+### Install DAY-EC Environment
 _from `daylily` root dir_
 
 ```bash
 
 ./bin/init_daycli 
 
-conda activate DAYCLI
+conda activate DAY-EC
 
-# DAYCLI should now be active... did it work?
+# DAY-EC should now be active... did it work?
 colr  'did it work?' 0,100,255 255,100,0
 
 ```
@@ -337,7 +337,7 @@ _from your local machine, in the daylily git repo root_
 _running in a tmux/screen session is advised as the copy may take 1-many hours_
 
 ```bash
-conda activate DAYCLI
+conda activate DAY-EC
 # help
 ./bin/create_daylily_omics_analysis_s3.sh -h
 
@@ -367,7 +367,7 @@ _this command will take ~5min to complete, and much longer if you expand to all 
 
 ```bash
 
-conda activate DAYCLI
+conda activate DAY-EC
 export AWS_PROFILE=daylily-service
 REGION=us-west-2          
 OUT_TSV=./init_daylily_cluster.tsv
@@ -706,12 +706,12 @@ Go to the `IAM Dashboard`, and under roles, search for the role `ParallelCluster
 ## PCUI
 Visit your url created when you built a PCUI
 
-## DAYCLI & AWS Parallel Cluster CLI (pcluster)
+## DAY-EC & AWS Parallel Cluster CLI (pcluster)
 
-### Activate The DAYCLI Conda Environment
+### Activate The DAY-EC Conda Environment
 
 ```bash
-conda activate DAYCLI
+conda activate DAY-EC
 ```
 
 ### `pcluster` CLI Usage
@@ -837,7 +837,7 @@ If there is no `~/projects/daylily` directory, or the `dyinit` command is not fo
 From your remote terminal that you created the cluster with, run the following commands to complete the headnode configuration.
 
 ```bash
-conda activate DAYCLI
+conda activate DAY-EC
 
 ./bin/daylily-cfg-headnode $PATH_TO_PEM $CLUSTER_AWS_REGION $AWS_PROFILE
 ```

--- a/bin/check_current_spot_market_by_zones.py
+++ b/bin/check_current_spot_market_by_zones.py
@@ -3,11 +3,11 @@
 import os
 import sys
 
-if os.environ.get("CONDA_DEFAULT_ENV") != "DAYCLI":
-    sys.stderr.write("Error: The DAYCLI conda environment is not active. run: \n\tconda activate DAYCLI\n")
+if os.environ.get("CONDA_DEFAULT_ENV") != "DAY-EC":
+    sys.stderr.write("Error: The DAY-EC conda environment is not active. run: \n\tconda activate DAY-EC\n")
     sys.exit(1)
 else:
-    print("DAYCLI conda environment is active, continuing...",file=sys.stderr)
+    print("DAY-EC conda environment is active, continuing...", file=sys.stderr)
 
 import yaml
 import subprocess

--- a/bin/daylily-create-ephemeral-cluster
+++ b/bin/daylily-create-ephemeral-cluster
@@ -81,7 +81,7 @@ if  yq --version &> /dev/null; then
     echo "yq is installed, proceeding."
 else
     echo "❌ Error: yq is not detected."
-    echo "Please run conda activate DAYCLI (or bash bin/init_daycli) to proceed."
+    echo "Please run conda activate DAY-EC (or bash bin/init_daycli) to proceed."
     exit 3  # Exit the function with an error status
 fi
 
@@ -218,14 +218,14 @@ fi
 echo "Conda version $current_version meets the requirement of $required_version or higher."
 
 
-# Check if the Conda environment DAYCLI is active
-if [[ "$CONDA_DEFAULT_ENV" == "DAYCLI" ]]; then
-    echo "The Conda environment DAYCLI is active, proceeding."
+# Check if the Conda environment DAY-EC is active
+if [[ "$CONDA_DEFAULT_ENV" == "DAY-EC" ]]; then
+    echo "The Conda environment DAY-EC is active, proceeding."
 else
-    echo "The Conda environment DAYCLI is not active or missing."
+    echo "The Conda environment DAY-EC is not active or missing."
     echo ""
-    echo "Please activate the DAYCLI environment by running:"
-    echo "    conda activate DAYCLI"
+    echo "Please activate the DAY-EC environment by running:"
+    echo "    conda activate DAY-EC"
     echo ""
     echo "If the environment does not exist, create it by running:"
     echo "    ./bin/init_daycli"
@@ -234,17 +234,17 @@ fi
 
 
 # Activate or create the Daylily CLI conda environment
-if conda env list | grep -q "^DAYCLI "; then
-    echo "Conda environment 'DAYCLI' already exists. Activating it."
+if conda env list | grep -q "^DAY-EC "; then
+    echo "Conda environment 'DAY-EC' already exists. Activating it."
 else
-    echo "Creating 'DAYCLI' environment."
+    echo "Creating 'DAY-EC' environment."
     source bin/init_daycli
     if [[ $? -ne 0 ]]; then
-        echo "❌ Error: Failed to create the 'DAYCLI' environment. Exiting."
+        echo "❌ Error: Failed to create the 'DAY-EC' environment. Exiting."
         exit 3
     fi
 fi
-conda activate DAYCLI
+conda activate DAY-EC
 
 AWS_CLI_USER=$(aws sts get-caller-identity --region $region --profile $AWS_PROFILE --query "Arn" --output text | awk -F '/' '{print $2}')
 

--- a/bin/daylily-delete-ephemeral-cluster
+++ b/bin/daylily-delete-ephemeral-cluster
@@ -6,10 +6,10 @@ unset cluster_name
 
 # Source Conda's base environment setup
 source $(conda info --base)/etc/profile.d/conda.sh
-conda activate DAYCLI
+conda activate DAY-EC
 
 if [ $? -ne 0 ]; then
-    echo "Error: Conda environment 'DAYCLI' not found. Please create it before running this script."
+    echo "Error: Conda environment 'DAY-EC' not found. Please create it before running this script."
     exit 1
 fi
 

--- a/bin/daylily-ssh-into-headnode
+++ b/bin/daylily-ssh-into-headnode
@@ -28,11 +28,11 @@ if [ -n "$ZSH_VERSION" ]; then
 fi
 
 # Activate or create the Daylily CLI conda environment
-if conda env list | grep  "DAYCLI"; then
-    echo "Conda environment 'DAYCLI' already exists."
-    conda activate DAYCLI
+if conda env list | grep  "DAY-EC"; then
+    echo "Conda environment 'DAY-EC' already exists."
+    conda activate DAY-EC
 else
-    echo "'DAYCLI' environment not found. Attempting to create..."
+    echo "'DAY-EC' environment not found. Attempting to create..."
     source bin/init_daylily.sh
 
 fi

--- a/bin/helpers/login_to_cluster.sh
+++ b/bin/helpers/login_to_cluster.sh
@@ -1,2 +1,2 @@
 #source me
-conda activate DAYCLI && cluster_name=$(conda activate DAYCLI && pcluster list-clusters | grep 'clusterName' | perl -pe 's/.*\: \"(.*)\"\,.*/$1/g;') && cluster_ip=$(pcluster describe-cluster -n $cluster_name | grep 'publicIpAddress' | perl -pe 's/.*\: \"(.*)\"\,.*/$1/g;') &&ssh -i ~/.ssh/daylily2.pem ubuntu@$cluster_ip
+conda activate DAY-EC && cluster_name=$(conda activate DAY-EC && pcluster list-clusters | grep 'clusterName' | perl -pe 's/.*\: \"(.*)\"\,.*/$1/g;') && cluster_ip=$(pcluster describe-cluster -n $cluster_name | grep 'publicIpAddress' | perl -pe 's/.*\: \"(.*)\"\,.*/$1/g;') &&ssh -i ~/.ssh/daylily2.pem ubuntu@$cluster_ip

--- a/bin/init_daycli
+++ b/bin/init_daycli
@@ -21,19 +21,19 @@ if ! command -v conda &> /dev/null; then
 fi
 
 # Activate or create the Daylily CLI conda environment
-if conda env list | grep -q "^DAYCLI "; then
-    echo "Conda environment 'DAYCLI' already exists!"
+if conda env list | grep -q "^DAY-EC "; then
+    echo "Conda environment 'DAY-EC' already exists!"
     echo "Activate with: "
-    echo "    conda activate DAYCLI"
+    echo "    conda activate DAY-EC"
     exit 3
 else
-    echo "Creating 'DAYCLI' environment."
-    conda env create -y -n DAYCLI -f config/day/daycli.yaml
+    echo "Creating 'DAY-EC' environment."
+    conda env create -y -n DAY-EC -f config/day/daycli.yaml
     if [ $? -ne 0 ]; then
-        echo "Error: Failed to create 'DAYCLI' environment."
+        echo "Error: Failed to create 'DAY-EC' environment."
         exit 1
     fi
 fi
 
 echo "Daylily CLI environment is ready!  Activate with: "
-echo "    conda activate DAYCLI"
+echo "    conda activate DAY-EC"

--- a/config/day/day_env_installer.sh
+++ b/config/day/day_env_installer.sh
@@ -2,33 +2,33 @@
 
 ################################################################################
 # Script Name: day_env_installer.sh
-# Description: Sets up Miniconda and installs the DAY conda environment.
-# Usage:       source ./day_env_installer.sh DAY
-#              Provide 'DAY' as the argument to start the installation.
-#              If the 'DAY' environment already exists, the script will prompt accordingly.
+# Description: Sets up Miniconda and installs the DAYOA conda environment.
+# Usage:       source ./day_env_installer.sh DAYOA
+#              Provide 'DAYOA' as the argument to start the installation.
+#              If the 'DAYOA' environment already exists, the script will prompt accordingly.
 ################################################################################
 
 
 # Function to display usage information
 usage() {
-    echo "Usage: source $0 DAY"
-    echo "This script installs Miniconda and sets up the DAY conda environment."
-    echo "Provide 'DAY' as the argument to start the installation."
+    echo "Usage: source $0 DAYOA"
+    echo "This script installs Miniconda and sets up the DAYOA conda environment."
+    echo "Provide 'DAYOA' as the argument to start the installation."
     return 2
 }
 
 # Check if the correct argument is provided
-DY_ENVNAME="DAY"
+DY_ENVNAME="DAYOA"
 if [[ "$1" != "$DY_ENVNAME" ]]; then
     echo "Hello! This is the __ $DY_ENVNAME __ installation script."
     echo ""
-    echo "The DAY environment installs the software needed to trigger Snakemake and run the Day (dy-) CLI."
-    echo "To run and start the install, provide 'DAY' as the argument."
+    echo "The DAYOA environment installs the software needed to trigger Snakemake and run the Day (dy-) CLI."
+    echo "To run and start the install, provide 'DAYOA' as the argument."
     echo ""
-    echo "Usage: $0 DAY"
+    echo "Usage: $0 DAYOA"
     echo ""
-    echo "If you have an existing DAY install, you may need to remove it first:"
-    echo "  conda env remove -n DAY"
+    echo "If you have an existing DAYOA install, you may need to remove it first:"
+    echo "  conda env remove -n DAYOA"
     echo ""
     usage
 fi
@@ -102,28 +102,28 @@ conda config --set execute_threads 4 || echo 'Failed to set execute_threads'
 conda config --set always_yes yes || echo 'Failed to set always_yes'
 conda config --set default_threads 10 || echo 'Failed to set default_threads'
 
-# Check if the DAY environment already exists
+# Check if the DAYOA environment already exists
 if conda env list | grep -q "^$DY_ENVNAME\s"; then
     echo ""
-    echo "It appears you have a DAY environment already."
-    echo "You may need to manually remove the conda env dir for DAY and try again."
+    echo "It appears you have a DAYOA environment already."
+    echo "You may need to manually remove the conda env dir for DAYOA and try again."
     echo "To remove the environment, run:"
-    echo "  conda env remove -n DAY"
+    echo "  conda env remove -n DAYOA"
     return 0
 else
     conda install -y -n base -c conda-forge yq || echo 'Failed to install yq'
     cp bin/day-clone ~/miniconda3/condabin/day-clone || echo 'Failed to copy day-clone script to ~/minconda3/condabin'
-    echo "Installing DAY environment..."
-    # Create the DAY environment
+    echo "Installing DAYOA environment..."
+    # Create the DAYOA environment
     if conda env create -n "$DY_ENVNAME" -f "$SCRIPT_DIR/day.yaml"; then
-        echo "DAY environment created successfully."
+        echo "DAYOA environment created successfully."
         echo ""
         echo "Try the following commands to get started:"
         echo "  source dyinit --project <PROJECT>"
         echo "  dy-a local"
         echo "  dy-r help"
     else
-        echo "Failed to create DAY environment."
+        echo "Failed to create DAYOA environment."
         return 1
     fi
 fi

--- a/config/day/day_env_installer.sh_o
+++ b/config/day/day_env_installer.sh_o
@@ -12,7 +12,7 @@ mkdir -p ~$USER/.parallel
 ################################################################################
 # Sets up miniconda and other environments for imputation.
 ################################################################################
-DY_ENVNAME="DAY"
+DY_ENVNAME="DAYOA"
 
 
 if [[ $1 != "$DY_ENVNAME" ]]; then
@@ -20,16 +20,16 @@ if [[ $1 != "$DY_ENVNAME" ]]; then
     echo """
     Hello! This is the  __ $DY_ENVNAME ___ installation script.
 
-    The DAY env installs the s/w needed to trigger snakemake and run the day (abbreviated to dy-) CLI.  The tools DAY can run have individual environments which are managed by snakemake. You should not need to worry about them(tm).  This code continues to run on both Navops and local
+    The DAYOA env installs the s/w needed to trigger snakemake and run the day (abbreviated to dy-) CLI.  The tools DAYOA can run have individual environments which are managed by snakemake. You should not need to worry about them(tm).  This code continues to run on both Navops and local
 
 An important detail:
 
-***one*** If you have an existing DAY install, the DAY install will be skipped ==> it must be rebuilt from scratch to save many headaches<==.  To remove the DAY env, activate conda, but not DAY, and run:
-   `conda env remove -n DAY`
+***one*** If you have an existing DAYOA install, the DAYOA install will be skipped ==> it must be rebuilt from scratch to save many headaches<==.  To remove the DAYOA env, activate conda, but not DAYOA, and run:
+   `conda env remove -n DAYOA`
 
-When that is complete, you may run this script.  If DAY is present and you run this scirpt-- nothing very meaningful should happen.
+When that is complete, you may run this script.  If DAYOA is present and you run this scirpt-- nothing very meaningful should happen.
 
-To run and start the install, rather than see this message, provide just one argument 'DAY'
+To run and start the install, rather than see this message, provide just one argument 'DAYOA'
 """
     return 2
 fi
@@ -95,15 +95,15 @@ conda config --add channels bioconda
 (conda config --set always_yes yes && echo 'conda always yes set' ) || echo 'failed to set conda yes';
 (conda config --set default_threads 10 && echo "DefThreads=44")      || echo 'failed to set conda default threads';
 
-#  Install DAY If Not Present.
+#  Install DAYOA If Not Present.
 
-mgcnt=$(ls -d1 "$(dirname $(which conda))"/../envs/DAY | wc -l)
+mgcnt=$(ls -d1 "$(dirname $(which conda))"/../envs/DAYOA | wc -l)
 if [[ "$mgcnt" == "0" ]]; then
-    echo "Installing DAY \(which will be sourced for you when you \'source dyinit  --project <PROJECT> \' \(see docs\)  you should not need to source MG directly.  Beginning install... "
+    echo "Installing DAYOA \(which will be sourced for you when you \'source dyinit  --project <PROJECT> \' \(see docs\)  you should not need to source MG directly.  Beginning install... "
     echo "..."
     sleep 1.4
 
-    (export PIP_NO_INPUT=1 && export PIP_INDEX_URL="https://pypi.org/simple" && export PIP_EXTRA_INDEX_URL="https://pypi.org/simple"  &&  conda env create   -n DAY -f $SCRIPT_DIR/DAY.yaml && echo "DAY env created") || echo "DAY env not created"
+    (export PIP_NO_INPUT=1 && export PIP_INDEX_URL="https://pypi.org/simple" && export PIP_EXTRA_INDEX_URL="https://pypi.org/simple"  &&  conda env create   -n DAYOA -f $SCRIPT_DIR/DAY.yaml && echo "DAYOA env created") || echo "DAYOA env not created"
 
     echo "Install exited with > $? < (if not zero, not the best sign)."
     echo "try the following:
@@ -120,7 +120,7 @@ if [[ "$mgcnt" == "0" ]]; then
 else
     dn="$(dirname $(which conda))"/../envs/
     echo "
-       It appears you have a DAY env (located $dn ), or part of one at least.  You may need to manually remove the conda env dir for DAY, and hack a conf file (google it to be sure).  Then try this again."
+       It appears you have a DAYOA env (located $dn ), or part of one at least.  You may need to manually remove the conda env dir for DAYOA, and hack a conf file (google it to be sure).  Then try this again."
 
 fi;
 

--- a/docs/daylib/README.md
+++ b/docs/daylib/README.md
@@ -6,7 +6,7 @@
 ## Making libs available
 
 ```bash
-conda activate DAYCLI
+conda activate DAY-EC
 cd ~/projects/daylily
 pip install -e .
 ```


### PR DESCRIPTION
## Summary
- update Python and shell tooling to expect the renamed DAY-EC conda environment
- refresh documentation to instruct users to activate DAY-EC
- retitle the omics-analysis conda installer scripts from DAY to DAYOA

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cde6686bc48331b655f7c82ed1d80e