### PR TITLE
Make AWS profile flags optional with environment fallback

### DIFF
--- a/bin/check_current_spot_market_by_zones.py
+++ b/bin/check_current_spot_market_by_zones.py
@@ -9,10 +9,11 @@ if os.environ.get("CONDA_DEFAULT_ENV") != "DAY-EC":
 else:
     print("DAY-EC conda environment is active, continuing...", file=sys.stderr)
 
-import yaml
-import subprocess
-import statistics
 import argparse
+import statistics
+import subprocess
+import time
+import yaml
 from math import isnan, fsum
 from tabulate import tabulate
 from colr import color
@@ -117,9 +118,8 @@ def parse_arguments():
     )
     
     parser.add_argument(
-        "--profile", 
-        required=True,
-        help="AWS CLI profile, *you must set* AWS_PROFILE=profile and specify that same profile string here (required)."
+        "--profile",
+        help="AWS CLI profile to use (defaults to AWS_PROFILE environment variable)."
     )
     
     parser.add_argument(
@@ -253,6 +253,45 @@ def parse_arguments():
     )
     
     return parser.parse_args()
+
+
+def resolve_aws_profile(profile_argument):
+    """Determine which AWS profile to use and ensure it is valid."""
+
+    profile = profile_argument or os.environ.get('AWS_PROFILE')
+    if not profile:
+        print("Error: AWS_PROFILE is not set. Please export AWS_PROFILE or supply --profile.", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        result = subprocess.run(
+            ["aws", "configure", "list-profiles"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        print("Error: AWS CLI is not installed or not found in PATH.", file=sys.stderr)
+        sys.exit(1)
+    except subprocess.CalledProcessError as exc:
+        message = exc.stderr.strip() or exc.stdout.strip() or str(exc)
+        print(f"Error listing AWS profiles: {message}", file=sys.stderr)
+        sys.exit(1)
+
+    available_profiles = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    if profile not in available_profiles:
+        print(f"Error: AWS profile '{profile}' not found. Please set AWS_PROFILE to a valid profile.", file=sys.stderr)
+        sys.exit(1)
+
+    os.environ['AWS_PROFILE'] = profile
+
+    if profile == 'default':
+        print("WARNING: AWS_PROFILE is set to 'default'. Sleeping for 1 second...")
+        time.sleep(1)
+    else:
+        print(f"Using AWS profile: {profile}")
+
+    return profile
 
 def calculate_vcpu_mins(args):
     """Calculate total vCPU-minutes based on coverage."""
@@ -471,23 +510,10 @@ def main():
         print(e)
         return
 
-    if args.profile == "SETME":
-        print(f"\n\nERROR:: Your AWS_PROFILE is set to >{os.getenv('AWS_PROFILE')}<, Please set your AWS_PROFILE environment variable and specify the same string with --profile.\n")
-        raise SystemExit
-    if os.environ.get('AWS_PROFILE','') == '':
-        os.environ['AWS_PROFILE'] = args.profile
-    elif args.profile != os.environ['AWS_PROFILE']:
-        print(f"\n\nERROR:: Your AWS_PROFILE is set to >{os.getenv('AWS_PROFILE')}<, Please set your AWS_PROFILE environment variable and specify the same string with --profile.\n")
-        raise SystemExit
-    elif args.profile == os.environ['AWS_PROFILE']:
-        print(f"\n\nAWS_PROFILE is set to >{os.getenv('AWS_PROFILE')}< and profile passed is >{args.profile}<, all good.\n")
-    else:
-        print(f"\n\nAWS_PROFILE is set to >{os.getenv('AWS_PROFILE')}< and profile passed is >{args.profile}<, there is a problem.\n")
-        raise SystemExit
+    profile = resolve_aws_profile(args.profile)
 
-    
     zones = args.zones.split(',')
-    spot_data = collect_spot_prices(instance_types, zones, args.profile)
+    spot_data = collect_spot_prices(instance_types, zones, profile)
     vcpu_mins = calculate_vcpu_mins(args)
 
     # Calculate statistics for each zone

--- a/bin/daylily-create-ephemeral-cluster
+++ b/bin/daylily-create-ephemeral-cluster
@@ -9,11 +9,46 @@ pass_on_warn=0  # Default for warnings causing failures
 
 # Function to display help
 usage() {
-    echo "Usage: $0 --profile AWS_PROFILE [--region-az REGION-AZ] [--pass-on-warn]"
+    echo "Usage: $0 [--profile AWS_PROFILE] [--region-az REGION-AZ] [--pass-on-warn]"
     echo "       --region-az REGION-AZ   Specify the AWS region and availability zone (ie: us-west-2b)"
     echo "       --pass-on-warn          Allow warnings to pass without failure (default: false)"
-    echo "       --profile  aws profile to use"
+    echo "       --profile  AWS profile to use (defaults to AWS_PROFILE environment variable)"
     echo " .     --config <path>       Path to the daylily-create-ephemeral-cluster config, default: ./.dayephmeral.env)"
+}
+
+
+resolve_aws_profile() {
+    local provided_profile="$1"
+    local final_profile=""
+
+    if [[ -n "$provided_profile" ]]; then
+        final_profile="$provided_profile"
+    elif [[ -n "${AWS_PROFILE:-}" ]]; then
+        final_profile="$AWS_PROFILE"
+    else
+        echo "❌ Error: AWS_PROFILE is not set. Please export AWS_PROFILE or use --profile." >&2
+        exit 3
+    fi
+
+    local available_profiles
+    if ! available_profiles=$(aws configure list-profiles 2>/dev/null); then
+        echo "❌ Error: Unable to list AWS profiles. Ensure the AWS CLI is installed and configured." >&2
+        exit 3
+    fi
+
+    if ! grep -Fxq "$final_profile" <<<"$available_profiles"; then
+        echo "❌ Error: AWS profile '$final_profile' not found. Please set AWS_PROFILE to a valid profile." >&2
+        exit 3
+    fi
+
+    export AWS_PROFILE="$final_profile"
+
+    if [[ "$AWS_PROFILE" == "default" ]]; then
+        echo "⚠️ WARNING: AWS_PROFILE is set to 'default'. Sleeping for 1 second..."
+        sleep 1
+    else
+        echo "ℹ️ Using AWS profile: $AWS_PROFILE"
+    fi
 }
 
 
@@ -23,14 +58,10 @@ if [[ $# -eq 0 ]]; then
     exit 0
 fi
 
-if [ -z "$AWS_PROFILE" ]; then
-    echo "❌ Error: AWS_PROFILE is not set."
-    exit 1  # Exit the function with an error status
-fi
-
 CONFIG_FILE="config/daylily_ephemeral_cluster.yaml"
 
 # Parse command-line arguments
+profile_arg=""
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --region-az)
@@ -47,7 +78,7 @@ while [[ $# -gt 0 ]]; do
             exit 0
             ;;
         --profile)
-            AWS_PROFILEIN="$2"
+            profile_arg="$2"
             shift 2
             ;;
         --config)
@@ -62,15 +93,7 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-if [[ -z "$AWS_PROFILE" ]]; then
-    echo "❌ Error: --profile flag not set"
-    exit 3  # Exit the function with an error status
-fi
-
-if [[ "$AWS_PROFILE" != "$AWS_PROFILEIN" ]]; then
-    echo "❌ Error: AWS_PROFILE and --profile must match: $AWS_PROFILE and $AWS_PROFILEIN"
-    exit 3  # Exit the function with an error status
-fi
+resolve_aws_profile "$profile_arg"
 
 if [[ -z "$region_az" ]]; then
     echo "❌ Error: --region-az flag not set"
@@ -160,12 +183,6 @@ else
     exit 3  # Exit the function with an error status
 fi
 
-if [[ "$AWS_PROFILEIN" != "$AWS_PROFILE" ]]; then
-    echo "❌ Error: AWS_PROFILE and --profile must match: $AWS_PROFILE and $AWS_PROFILEIN"
-    exit 3  # Exit the function with an error status
-fi
-
-AWS_PROFILE=$AWS_PROFILE
 echo "YOUR AWS_PROFILE IS NOW SET TO: $AWS_PROFILE"
 
 # Function to handle warnings


### PR DESCRIPTION
## Summary
- make the `--profile` flag optional for daylily shell utilities by falling back to the AWS_PROFILE environment variable and validating the profile before continuing
- add shared AWS profile validation to the Python pricing/spot market helpers so they error on missing or invalid profiles and warn when "default" is selected
- ensure heartbeat provisioning/teardown uses the resolved profile when creating boto3 sessions, keeping profile handling consistent across tooling

## Testing
- python -m compileall bin/calcuate_spotprice_for_cluster_yaml.py bin/check_current_spot_market_by_zones.py bin/check_current_spot_market_by_zones_wcapacity.py bin/helpers/setup_cluster_heartbeat.py bin/helpers/teardown_cluster_heartbeat.py

------
https://chatgpt.com/codex/tasks/task_e_68cfc61577d8833197ce9024fef10c65