### PR TITLE
Install day-clone from ephemeral repo during headnode setup

### DIFF
--- a/bin/day-clone
+++ b/bin/day-clone
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Clone Daylily analysis repositories into the shared FSx workspace."""
+
+import argparse
+import getpass
+import os
+import subprocess
+import sys
+from typing import Any, Dict, List, Optional, Tuple
+
+
+CONFIG_DIR = os.path.expanduser("~/.config/daylily")
+GLOBAL_CONFIG_PATH = os.path.join(CONFIG_DIR, "daylily_cli_global.yaml")
+AVAILABLE_REPOS_PATH = os.path.join(CONFIG_DIR, "daylily_available_repositories.yaml")
+
+
+class ConfigError(RuntimeError):
+    """Raised when configuration files are missing or malformed."""
+
+
+def _strip_inline_comment(value: str) -> str:
+    """Remove inline comments that are not within quotes."""
+    in_single = False
+    in_double = False
+    for idx, char in enumerate(value):
+        if char == "'" and not in_double:
+            in_single = not in_single
+        elif char == '"' and not in_single:
+            in_double = not in_double
+        elif char == '#' and not in_single and not in_double:
+            return value[:idx].rstrip()
+    return value
+
+
+def _parse_simple_yaml(path: str) -> Dict[str, Any]:
+    """Parse a minimal subset of YAML containing nested dictionaries.
+
+    This parser is intentionally lightweight and supports the structures used
+    in the Daylily configuration files. It handles key/value pairs and nested
+    dictionaries that rely on indentation. Lists and complex YAML constructs
+    are intentionally unsupported.
+    """
+    if not os.path.exists(path):
+        raise ConfigError(f"Configuration file not found: {path}")
+
+    root: Dict[str, Any] = {}
+    stack: List[Tuple[Dict[str, Any], int]] = [(root, -1)]
+
+    with open(path, "r", encoding="utf-8") as handle:
+        for lineno, raw_line in enumerate(handle, start=1):
+            if not raw_line.strip():
+                continue
+            stripped = raw_line.strip()
+            if stripped.startswith("#") or stripped == "---":
+                continue
+
+            indent = len(raw_line) - len(raw_line.lstrip(" "))
+            while stack and indent <= stack[-1][1]:
+                stack.pop()
+            parent = stack[-1][0]
+
+            if ":" not in stripped:
+                raise ConfigError(
+                    f"Invalid line in {path}:{lineno}: '{raw_line.rstrip()}'"
+                )
+
+            key, value = stripped.split(":", 1)
+            key = key.strip()
+            value = _strip_inline_comment(value).strip()
+
+            if not key:
+                raise ConfigError(
+                    f"Missing key in {path}:{lineno}: '{raw_line.rstrip()}'"
+                )
+
+            if not value:
+                new_dict: Dict[str, Any] = {}
+                parent[key] = new_dict
+                stack.append((new_dict, indent))
+                continue
+
+            if (value.startswith('"') and value.endswith('"')) or (
+                value.startswith("'") and value.endswith("'")
+            ):
+                value = value[1:-1]
+
+            parent[key] = value
+
+    return root
+
+
+def load_global_config() -> Dict[str, Any]:
+    config = _parse_simple_yaml(GLOBAL_CONFIG_PATH)
+    if "daylily" not in config:
+        raise ConfigError(
+            f"Missing 'daylily' section in {GLOBAL_CONFIG_PATH}."
+        )
+    return config["daylily"]
+
+
+def load_available_repos() -> Tuple[str, Dict[str, Dict[str, Any]]]:
+    config = _parse_simple_yaml(AVAILABLE_REPOS_PATH)
+    repositories = config.get("repositories")
+    if not isinstance(repositories, dict) or not repositories:
+        raise ConfigError(
+            f"No repositories defined in {AVAILABLE_REPOS_PATH}."
+        )
+    default_repo = config.get("default_repository")
+    if not default_repo:
+        # Fall back to the first repository key for backwards compatibility.
+        default_repo = next(iter(repositories.keys()))
+    return default_repo, repositories
+
+
+def ensure_directory(path: str) -> None:
+    os.makedirs(path, exist_ok=True)
+
+
+def clone_repository(
+    git_url: str,
+    destination: str,
+    ref: Optional[str],
+) -> None:
+    cmd = ["git", "clone"]
+    if ref:
+        cmd.extend(["--branch", ref])
+    cmd.extend([git_url, destination])
+    try:
+        subprocess.run(cmd, check=True)
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(
+            f"Git clone failed with exit code {exc.returncode}."
+        ) from exc
+
+
+def derive_default_path(repo_url: str) -> str:
+    basename = os.path.basename(repo_url)
+    if basename.endswith(".git"):
+        basename = basename[:-4]
+    return basename or "repository"
+
+
+def print_available_repositories(repositories: Dict[str, Dict[str, Any]]) -> None:
+    print("Available repositories:\n")
+    for key, repo in repositories.items():
+        name = repo.get("display_name", key)
+        print(f"- {key}: {name}")
+        if description := repo.get("description"):
+            print(f"    {description}")
+        default_ref = repo.get("default_ref")
+        if default_ref:
+            print(f"    Default ref: {default_ref}")
+        print()
+
+
+def main(argv: List[str]) -> int:
+    try:
+        global_cfg = load_global_config()
+        default_repo_key, available_repos = load_available_repos()
+    except ConfigError as err:
+        print(f"Error: {err}", file=sys.stderr)
+        return 2
+
+    parser = argparse.ArgumentParser(
+        description="Clone Daylily analysis repositories into the FSx analysis workspace.",
+    )
+    parser.add_argument(
+        "-d",
+        "--destination",
+        help="Name of the analysis workspace directory to create under the user-specific root.",
+    )
+    parser.add_argument(
+        "-t",
+        "--git-tag",
+        help="Git branch or tag to clone. Defaults to the repository's configured default.",
+    )
+    parser.add_argument(
+        "-r",
+        "--git-repo",
+        help="Override the git repository URL to clone. Overrides --repository.",
+    )
+    parser.add_argument(
+        "-c",
+        "--clone-root",
+        help="Root directory where analysis workspaces are created. Defaults to the configured analysis_root.",
+    )
+    parser.add_argument(
+        "-u",
+        "--user-name",
+        help="User directory to create within the clone root. Defaults to the current user.",
+    )
+    parser.add_argument(
+        "-w",
+        "--which-one",
+        choices=["https", "ssh"],
+        default="https",
+        help="Clone using https or ssh (default: https).",
+    )
+    parser.add_argument(
+        "--repository",
+        help="Key of the repository defined in daylily_available_repositories.yaml to clone.",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="List available repositories and exit.",
+    )
+
+    args = parser.parse_args(argv)
+
+    if args.list:
+        print_available_repositories(available_repos)
+        return 0
+
+    if not args.destination:
+        print(
+            "Error: --destination (-d) is required when cloning a repository.",
+            file=sys.stderr,
+        )
+        return 1
+
+    clone_root = args.clone_root or global_cfg.get("analysis_root")
+    if not clone_root:
+        print(
+            "Error: analysis_root is not configured in daylily_cli_global.yaml.",
+            file=sys.stderr,
+        )
+        return 2
+
+    clone_root = os.path.abspath(os.path.expanduser(clone_root))
+    if not os.path.isdir(clone_root):
+        print(
+            f"Error: clone_root directory '{clone_root}' does not exist.",
+            file=sys.stderr,
+        )
+        return 1
+
+    user_name = args.user_name or os.environ.get("USER") or getpass.getuser()
+    user_root = os.path.join(clone_root, user_name)
+    ensure_directory(user_root)
+
+    destination_root = os.path.join(user_root, args.destination)
+    if os.path.exists(destination_root):
+        print(
+            f"Error: destination '{destination_root}' already exists.",
+            file=sys.stderr,
+        )
+        return 1
+
+    repo_config: Optional[Dict[str, Any]] = None
+    if not args.git_repo:
+        repo_key = args.repository or default_repo_key
+        repo_config = available_repos.get(repo_key)
+        if repo_config is None:
+            print(
+                f"Error: repository '{repo_key}' is not defined in daylily_available_repositories.yaml.",
+                file=sys.stderr,
+            )
+            return 1
+    else:
+        repo_key = "custom"
+
+    if args.git_repo:
+        git_url = args.git_repo
+        relative_path = derive_default_path(git_url)
+        default_ref = None
+    else:
+        preferred_key = "https_url" if args.which_one == "https" else "ssh_url"
+        git_url = repo_config.get(preferred_key, "")
+        if not git_url:
+            alternative_key = "ssh_url" if preferred_key == "https_url" else "https_url"
+            git_url = repo_config.get(alternative_key, "")
+        if not git_url:
+            print(
+                f"Error: repository '{repo_key}' does not define a git URL for cloning.",
+                file=sys.stderr,
+            )
+            return 1
+        relative_path = repo_config.get("relative_path") or repo_key
+        default_ref = repo_config.get("default_ref")
+
+    git_ref = args.git_tag or default_ref
+
+    relative_path = os.path.basename(relative_path.rstrip("/"))
+    target_repo_dir = os.path.join(destination_root, relative_path)
+    ensure_directory(destination_root)
+
+    print("Cloning repository...")
+    try:
+        clone_repository(git_url, target_repo_dir, git_ref)
+    except RuntimeError as err:
+        print(f"Error: {err}", file=sys.stderr)
+        return 1
+
+    print()
+    print("Great success! Daylily repository cloned.")
+    print(f"Repository: {git_url}")
+    if git_ref:
+        print(f"Reference : {git_ref}")
+    print(f"Location  : {target_repo_dir}")
+    print()
+    print("To get started:")
+    print(f"  cd {target_repo_dir}")
+    print("  # initialize and run the analysis repository per its documentation")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/bin/daylily-cfg-headnode
+++ b/bin/daylily-cfg-headnode
@@ -11,10 +11,6 @@ duser="ubuntu"
 
 CONFIG_FILE="config/daylily_cli_global.yaml"
 
-git_tag=$(yq -r '.daylily.git_tag' "$CONFIG_FILE")
-git_repo=$(yq -r '.daylily.git_repo' "$CONFIG_FILE")
-git_analysis_repo_tag=$(yq -r '.daylily.git_analysis_repo_tag' "$CONFIG_FILE")
-git_analysis_repo=$(yq -r '.daylily.git_analysis_repo' "$CONFIG_FILE")
 git_ephemeral_cluster_repo_tag=$(yq -r '.daylily.git_ephemeral_cluster_repo_tag' "$CONFIG_FILE")
 git_ephemeral_cluster_repo=$(yq -r '.daylily.git_ephemeral_cluster_repo' "$CONFIG_FILE")
 daylily_image_cmd=$(yq -r '.daylily.daylily_image_cmd' "$CONFIG_FILE")
@@ -107,66 +103,32 @@ echo "Building the Daylily container on the head node..."
 ssh -t -i "$pem_file" ubuntu@"$cluster_ip_address"  -o StrictHostKeyChecking=no   -o UserKnownHostsFile=/dev/null  \
     " $daylily_image_cmd " 
 
-# Clone the Daylily repository to the head node
-echo "Cloning Daylily repository using https to the head node ~/projects"
+# Clone the daylily-ephemeral-cluster repository to the head node
+echo "Cloning daylily-ephemeral-cluster repository using https to the head node ~/projects"
 ssh -t -i "$pem_file" ubuntu@"$cluster_ip_address"  -o StrictHostKeyChecking=no   -o UserKnownHostsFile=/dev/null \
-    "mkdir -p ~/projects && cd ~/projects &&  git clone -b ${git_analysis_repo_tag} ${git_analysis_repo} daylily-omics-analysis"
+    "mkdir -p ~/projects && cd ~/projects &&  git clone -b ${git_ephemeral_cluster_repo_tag} ${git_ephemeral_cluster_repo} daylily-ephemeral-cluster"
 
-# Initialize and configure the Daylily environment on the head node
-echo "Configuring Daylily environment on the head node..."
+# Install shared tooling from the repo (day-clone, config files, etc.)
+echo "Installing head node tooling from the cloned repository..."
 ssh -t -i "$pem_file" ubuntu@"$cluster_ip_address" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-    "source ~/.bashrc && cd ~/projects/daylily-omics-analysis && source dyinit --skip-project-check && source bin/day_build BUILD"
+    "source ~/.bashrc && cd ~/projects/daylily-ephemeral-cluster && ./bin/install-daylily-headnode-tools"
 
-# Run a simple help test for Daylily remotely
-echo "Running a simple help test on the head node..."
-ssh -t -i "$pem_file" ubuntu@"$cluster_ip_address" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-    "source ~/.bashrc && cd ~/projects/daylily-omics-analysis && source dyinit --skip-project-check && source bin/day_activate local hg38 remote && ./bin/day_run help"
-
-
-
-# Finally, a quick test to confirm things are running as expected locally on the headnode
-echo "Run a quick test to ensure things are working as expected... [local run]"
-ssh -t -i "$pem_file" ubuntu@"$cluster_ip_address"  -o StrictHostKeyChecking=no   -o UserKnownHostsFile=/dev/null \
-    "source ~/.bashrc && cd ~/projects/daylily-omics-analysis && source dyinit --project daylily-global && source bin/day_activate local hg38 remote && ./bin/day_run  produce_deduplicated_bams -p -k -j 2 --config aligners=['strobe'] dedupers=['dppl']  "
-
-
+echo "day-clone is now available on the head node. Use it to clone analysis repositories such as daylily-omics-analysis."
 
 # Provide final instructions for SSH access to the head node
 echo "You can now SSH into the head node with the following command:"
 echo "        ssh -i $pem_file ubuntu@$cluster_ip_address"
 echo " "
 echo "Once logged in, as the 'ubuntu' user, run the following commands:"
-echo "  cd ~/projects/daylily-omics-analysis"
-echo "  source dyinit " 
-echo "  dy-a local"
-echo "  dy-g hg38"
-echo "  dy-r help"
+echo "  cd ~/projects/daylily-ephemeral-cluster"
+echo "  ./bin/day-clone --list"
+echo "  day-clone -d <analysis_name> [--repository <repo-key>]"
 echo " "
-echo ".... and remember to re-clone the repo for each new analysis in the /fsx/analysis_results directory for non-test uses."
+echo ".... this will clone the selected analysis repository into /fsx/analysis_results/<user>/<analysis_name>/"
 echo " "
 echo "Setup complete. "
 
 echo " "
-echo "___bonus round___"
-echo "Would you like to start building various caches needed to run jobs? [y/n]"
-
-
-# Dont really need this if using the updated ref bucket
-timeout 1 bash -c 'read -p "Press y to start or n to skip: " REPLY && echo "$REPLY"' && export REPLY=$REPLY
-
-if [[ "$REPLY" == "y" ]]; then
-    # start building the minimal cached envs
-    echo "Building some cached analysis environments to save a little time ... this can take a little time"
-    ssh -t -i "$pem_file" ubuntu@"$cluster_ip_address"  -o StrictHostKeyChecking=no   -o UserKnownHostsFile=/dev/null \
-        "source ~/.bashrc && cd ~/projects/daylily-omics-analysis && source dyinit --skip-project-check && source bin/day_activate local hg38 remote &&  ./bin/day_run  produce_snv_concordances -p -k -j 2 --config aligners=['strobe','bwa2a'] dedupers=['dppl'] snv_callers=['deep']  --conda-create-envs-only    "
-    echo " "
-    echo "Caches have built for the following tools: strobe, bwa2a, dppl, oct, deep"
-    echo " "
-else
-    # Print the command that would have been run
-    echo "Skipping cache building. Command would have been:"
-    echo -e "       ssh -t -i \"$pem_file\" ubuntu@\"$cluster_ip_address\" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \"source ~/.bashrc && cd ~/projects/daylily-omics-analysis && source dyinit --skip-project-check && source bin/day_activate local hg38 remote && ./bin/day_run produce_snv_concordances -p -k -j 2 --config aligners=['strobe','bwa2a'] dedupers=['dppl'] snv_callers=['oct','deep'] --conda-create-envs-only\" \n"
-fi
 echo "And, you may now access the headnode via the PCUI, via 'source bin/daylily-ssh-into-headnode', or SSH into the head node with the following command:"
 echo -e "       ssh -i $pem_file ubuntu@$cluster_ip_address\n"
 echo " "

--- a/bin/install-daylily-headnode-tools
+++ b/bin/install-daylily-headnode-tools
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONFIG_SOURCE_DIR="$REPO_ROOT/config"
+TARGET_CONFIG_DIR="$HOME/.config/daylily"
+
+mkdir -p "$TARGET_CONFIG_DIR"
+
+cp "$CONFIG_SOURCE_DIR/daylily_cli_global.yaml" "$TARGET_CONFIG_DIR/daylily_cli_global.yaml"
+cp "$CONFIG_SOURCE_DIR/daylily_available_repositories.yaml" "$TARGET_CONFIG_DIR/daylily_available_repositories.yaml"
+
+# Install day-clone into a system-wide location if possible, otherwise fall back to ~/.local/bin
+INSTALL_TARGET="/usr/local/bin/day-clone"
+if command -v sudo >/dev/null 2>&1; then
+    if sudo install -m 0755 "$REPO_ROOT/bin/day-clone" "$INSTALL_TARGET"; then
+        echo "day-clone installed to $INSTALL_TARGET"
+        exit 0
+    else
+        echo "Warning: failed to install day-clone to $INSTALL_TARGET with sudo. Falling back to user installation." >&2
+    fi
+fi
+
+USER_BIN_DIR="$HOME/.local/bin"
+mkdir -p "$USER_BIN_DIR"
+install -m 0755 "$REPO_ROOT/bin/day-clone" "$USER_BIN_DIR/day-clone"
+echo "day-clone installed to $USER_BIN_DIR/day-clone. Ensure $USER_BIN_DIR is on your PATH."

--- a/config/daylily_available_repositories.yaml
+++ b/config/daylily_available_repositories.yaml
@@ -1,0 +1,17 @@
+---
+default_repository: daylily-omics-analysis
+repositories:
+  daylily-omics-analysis:
+    display_name: "Daylily Omics Analysis"
+    description: "Primary whole genome and multiomics workflows."
+    https_url: https://github.com/Daylily-Informatics/daylily-omics-analysis.git
+    ssh_url: git@github.com:Daylily-Informatics/daylily-omics-analysis.git
+    default_ref: 0.7.333
+    relative_path: daylily-omics-analysis
+  rna-seq-star-deseq2:
+    display_name: "RNA-seq STAR + DESeq2"
+    description: "RNA sequencing alignment and differential expression analysis workflows."
+    https_url: https://github.com/Daylily-Informatics/rna-seq-star-deseq2.git
+    ssh_url: git@github.com:Daylily-Informatics/rna-seq-star-deseq2.git
+    default_ref: main
+    relative_path: rna-seq-star-deseq2


### PR DESCRIPTION
## Summary
- update the headnode configuration workflow to clone the daylily-ephemeral-cluster repository and install shared tooling
- add a headnode tool installer that copies configuration files and installs the day-clone helper script
- provide a Python-based day-clone script and repository catalog so analysis repos can be cloned via config-driven metadata

## Testing
- bin/day-clone --list
- bin/day-clone -h
- ./bin/install-daylily-headnode-tools

------
https://chatgpt.com/codex/tasks/task_e_68cfdd517bd08331988f382574f8cf2f