### PR TITLE
Use daylily-omics-references CLI for reference buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,17 @@ REGION=us-west-2
 
 ```
 
-> You may visit the `S3` console to confirm the bucket is being cloned as expected. The copy (if w/in `us-west-2` should take ~1hr, much longer across AZs.  
+The helper script is a thin wrapper around the
+[`daylily-omics-references`](https://github.com/Daylily-Informatics/daylily-omics-references)
+CLI (version `0.1.0`). Activating the `DAY-EC` conda environment installs the
+dependency automatically. You can also invoke the CLI directly:
+
+```bash
+daylily-omics-references --profile $AWS_PROFILE --region $REGION \
+  clone --bucket-prefix $BUCKET_PREFIX --version 0.7.131c --execute
+```
+
+> You may visit the `S3` console to confirm the bucket is being cloned as expected. The copy (if w/in `us-west-2` should take ~1hr, much longer across AZs.
 
 ---
 
@@ -446,6 +456,10 @@ REGION_AZ=us-west-2c
 
 ```
 
+During the run the script invokes the `daylily-omics-references` CLI to
+validate the selected reference bucket, preventing misconfigured buckets from
+reaching the cluster provisioning phase.
+
 ### Provide defaults with `DAY_EX_CFG`
 
 Configuration for every prompt in `bin/daylily-create-ephemeral-cluster` lives in a user-managed YAML file. Copy the template
@@ -475,7 +489,7 @@ export DAY_EX_CFG=$PWD/config/daylily_ephemeral_cluster.yaml
 
 - (_one per-region_) select the full path to your $HOME/.ssh/<mykey>.pem (from detected .pem files)
   
-- (_one per-region_) select the `s3` bucket you created and seeded, options presented will be any with names ending in `-omics-analysis`. Or you may select `1` and manually enter a s3 url.
+- (_one per-region_) select the `s3` bucket you created and seeded, options presented will be any with names ending in `-omics-analysis`. The script now verifies the bucket with the `daylily-omics-references` CLI and will halt if required data are missing. Or you may select `1` and manually enter a s3 url.
   
 - (_one per-region-az_) select the `Public Subnet ID` created when the cloudstack formation script was run earlier. **if none are detected, this will be auto-created for you via stack formation**
 

--- a/bin/create_daylily_omics_analysis_s3.sh
+++ b/bin/create_daylily_omics_analysis_s3.sh
@@ -1,39 +1,43 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -e  # Exit on any error
+set -euo pipefail
 
-# Check if the script is being sourced
-if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
-    echo "Error: This script is being sourced, not executed. Please execute this script."
-    return 3  # Return with error if sourced
-fi
-
-# Default values
-s3_reference_data_version="0.7.131c"
-region=""
-disable_dryrun=false # Default to true
-exclude_hg38_refs=false
-exclude_b37_refs=false
-exclude_giab_reads=false
-LOGFILE=""
-
-# Usage function
 usage() {
-    echo "Usage: $0 [OPTIONS]"
-    echo ""
-    echo "Options:"
-    echo "  --daylily-s3-version <version>       Set the Daylily S3 version ( default: 0.7.131c )"
-    echo "  --region <region>                    Region to CREATE the new bucket in ( required )"
-    echo "  --disable-dryrun                     Disable dry-run mode ( default: run in dry-run mode )"
-    echo "  --bucket-prefix <prefix>             Set the S3 bucket prefix ( required )"
-    echo "  --disable-warn                       Disable warnings ( default: run with warnings )"
-    echo "  --exclude-hg38-refs                  Skip copying hg38 references and annotations ( default: false )"
-    echo "  --exclude-b37-refs                   Skip copying b37 references and annotations ( default: false )"
-    echo "  --exclude-giab-reads                 Skip copying GIAB reads ( default: false )"
-    echo "  --profile                             AWS profile to use (defaults to AWS_PROFILE environment variable)"
-    echo "  --log-file                            Log file to write to ( default: ./create_daylily_s3_REGION.log )"
-    echo "  --help                               Show this help message"
-    exit 1
+    cat <<'USAGE'
+Usage: ./bin/create_daylily_omics_analysis_s3.sh [OPTIONS]
+
+Wrapper around the `daylily-omics-references` CLI that clones the
+Daylily omics analysis reference bucket into your account.
+
+Options:
+  --daylily-s3-version <version>  Reference data version to clone (default: 0.7.131c)
+  --region <region>               AWS region for the new bucket (required)
+  --bucket-prefix <prefix>        Prefix for the target bucket (required)
+  --disable-dryrun                Execute the clone instead of performing a dry-run
+  --disable-warn                  Acknowledge that the operation will create resources
+  --exclude-hg38-refs             Skip cloning hg38 references and annotations
+  --exclude-b37-refs              Skip cloning b37 references and annotations
+  --exclude-giab-reads            Skip cloning GIAB concordance reads
+  --profile <profile>             AWS profile to use (defaults to AWS_PROFILE env var)
+  --log-file <path>               File to capture AWS CLI output from the clone
+  --use-acceleration              Enable the S3 accelerate endpoint during cloning
+  -h, --help                      Show this message and exit
+USAGE
+}
+
+require_reference_cli() {
+    if ! command -v daylily-omics-references >/dev/null 2>&1; then
+        cat <<'ERR' >&2
+Error: 'daylily-omics-references' was not found in PATH.
+Install version 0.1.0 or newer with:
+
+    pip install "git+https://github.com/Daylily-Informatics/daylily-omics-references.git@0.1.0"
+
+The dependency is installed automatically when you create the DAY-EC
+conda environment; please ensure that environment is active.
+ERR
+        exit 2
+    fi
 }
 
 resolve_aws_profile() {
@@ -49,14 +53,18 @@ resolve_aws_profile() {
         exit 1
     fi
 
-    local available_profiles
-    if ! available_profiles=$(aws configure list-profiles 2>/dev/null); then
-        echo "Error: Unable to list AWS profiles. Ensure the AWS CLI is installed and configured." >&2
-        exit 1
-    fi
-
-    if ! grep -Fxq "$final_profile" <<<"$available_profiles"; then
-        echo "Error: AWS profile '$final_profile' not found. Please set AWS_PROFILE to a valid profile." >&2
+    if command -v aws >/dev/null 2>&1; then
+        local available_profiles
+        if ! available_profiles=$(aws configure list-profiles 2>/dev/null); then
+            echo "Error: Unable to list AWS profiles. Ensure the AWS CLI is installed and configured." >&2
+            exit 1
+        fi
+        if ! grep -Fxq "$final_profile" <<<"$available_profiles"; then
+            echo "Error: AWS profile '$final_profile' not found. Please set AWS_PROFILE to a valid profile." >&2
+            exit 1
+        fi
+    else
+        echo "Error: AWS CLI was not detected in PATH. Install and configure the AWS CLI before proceeding." >&2
         exit 1
     fi
 
@@ -70,277 +78,133 @@ resolve_aws_profile() {
     fi
 }
 
-# Parse command-line arguments
+reference_version="0.7.131c"
+region=""
+bucket_prefix=""
 profile_arg=""
-while [[ "$#" -gt 0 ]]; do
+log_file=""
+exclude_hg38=false
+exclude_b37=false
+exclude_giab=false
+execute_clone=false
+disable_warn=false
+use_acceleration=""
+
+while [[ $# -gt 0 ]]; do
     case "$1" in
-        --daylily-s3-version) s3_reference_data_version="$2"; shift 2;;
-        --region) region="$2"; shift 2;;
-        --disable-dryrun) disable_dryrun=true; shift 1;;
-        --bucket-prefix) bucket_prefix="$2"; shift 2;;
-        --disable-warn) disable_warn=true; shift 1;;
-        --exclude-hg38-refs) exclude_hg38_refs=true; shift 1;;
-        --exclude-b37-refs) exclude_b37_refs=true; shift 1;;
-        --exclude-giab-reads) exclude_giab_reads=true; shift 1;;
-        --profile) profile_arg="$2"; shift 2;;
-        --log-file) LOGFILE="$2"; shift 2;;
-        --help) usage;;
-        *) echo "Unknown parameter: $1"; usage;;
+        --daylily-s3-version)
+            reference_version="$2"
+            shift 2
+            ;;
+        --region)
+            region="$2"
+            shift 2
+            ;;
+        --bucket-prefix)
+            bucket_prefix="$2"
+            shift 2
+            ;;
+        --disable-dryrun)
+            execute_clone=true
+            shift
+            ;;
+        --disable-warn)
+            disable_warn=true
+            shift
+            ;;
+        --exclude-hg38-refs)
+            exclude_hg38=true
+            shift
+            ;;
+        --exclude-b37-refs)
+            exclude_b37=true
+            shift
+            ;;
+        --exclude-giab-reads)
+            exclude_giab=true
+            shift
+            ;;
+        --profile)
+            profile_arg="$2"
+            shift 2
+            ;;
+        --log-file)
+            log_file="$2"
+            shift 2
+            ;;
+        --use-acceleration)
+            use_acceleration="yes"
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown parameter: $1" >&2
+            usage >&2
+            exit 1
+            ;;
     esac
 done
 
+if [[ "$disable_warn" != true ]]; then
+    echo ""
+    echo "Warning: This command will create a new S3 bucket and clone reference data." >&2
+    echo "Re-run with --disable-warn if you understand and accept these actions." >&2
+    exit 1
+fi
+
+if [[ -z "$region" ]]; then
+    echo "Error: --region is required." >&2
+    usage >&2
+    exit 1
+fi
+
+if [[ -z "$bucket_prefix" ]]; then
+    echo "Error: --bucket-prefix is required." >&2
+    usage >&2
+    exit 1
+fi
+
+require_reference_cli
 resolve_aws_profile "$profile_arg"
 
-if [ "$LOGFILE" == "" ]; then
-    LOGFILE="./logs/create_daylily_s3_${region}.log"
+profile="$AWS_PROFILE"
+
+if [[ -z "$log_file" ]]; then
+    mkdir -p ./logs
+    log_file="./logs/create_daylily_s3_${region}.log"
+fi
+mkdir -p "$(dirname "$log_file")"
+
+if [[ -z "$use_acceleration" ]]; then
+    read -r -p "Use S3 acceleration endpoint? (y/N): " accel_response || accel_response=""
+    if [[ "$accel_response" =~ ^[Yy]$ ]]; then
+        use_acceleration="yes"
+    else
+        use_acceleration="no"
+    fi
 fi
 
-if [ "$disable_warn" != true ]; then
-    echo ""
-    echo "Usage: $0 [--bucket-prefix <prefix> [ --daylily-s3-version <version> (default 0.7.131c) ] [ --region <region> (default us-west-2) ] [ --disable-dryrun ] [ --help ] [ --disable-warn ]"
-    echo ""
-    echo "Warning: This script will create a new S3 bucket and copy data from the Daylily reference data bucket."
-    echo "The new bucket will be created with the prefix specified by the --bucket-prefix argument."
-    echo "ACCELERATED TRANSFER WILL BE USED. "
-    echo  ""
-    echo "--disable-warn flag is not set. If you are sure you want to proceed, please re-run the script with the --disable-warn flag."
-    exit 1
-fi
-
-if [[ "$s3_reference_data_version" != "0.7.131c" ]]; then
-    echo "Error: Only version '0.7.131c' is supported. Exiting."
-    exit 1
+if [[ "$execute_clone" == true ]]; then
+    echo "Executing clone operation (dry-run disabled)."
 else
-    echo "Using Daylily S3 reference data version: $s3_reference_data_version"
-    source_bucket="daylily-omics-analysis-references-public"
+    echo "Running in dry-run mode. Pass --disable-dryrun to perform the actual clone."
 fi
 
+cmd=(daylily-omics-references)
+[[ -n "$profile" ]] && cmd+=(--profile "$profile")
+[[ -n "$region" ]] && cmd+=(--region "$region")
+cmd+=(clone --bucket-prefix "$bucket_prefix" --region "$region" --version "$reference_version")
+[[ "$execute_clone" == true ]] && cmd+=(--execute)
+[[ "$use_acceleration" == "yes" ]] && cmd+=(--use-acceleration)
+[[ "$exclude_hg38" == true ]] && cmd+=(--exclude-hg38)
+[[ "$exclude_b37" == true ]] && cmd+=(--exclude-b37)
+[[ "$exclude_giab" == true ]] && cmd+=(--exclude-giab)
+[[ -n "$log_file" ]] && cmd+=(--log-file "$log_file")
 
-if [[ "$region" == "" ]]; then
-    echo "Please provide a region to create the new bucket in."
-    exit 1
-fi
+echo "Invoking: ${cmd[*]}"
+"${cmd[@]}"
 
-if [[ "$bucket_prefix" == "" ]]; then
-    echo "Please provide a bucket prefix."
-    exit 1
-fi
-
-echo ""
-echo ""
-echo " >  >>   >>> AWS_PROFILE: $AWS_PROFILE is being used."
-echo ""
-sleep 2
-
-new_bucket="${bucket_prefix}-omics-analysis-${region}"
-echo "Creating bucket: $new_bucket"
-
-accel_enabled="--endpoint-url https://s3-accelerate.amazonaws.com"
-# Prompt user to use acceleration endpoint or not
-read -p "Use S3 acceleration endpoint? (y/n): " use_accel
-
-if [[ "$use_accel" == "y" || "$use_accel" == "Y" ]]; then
-    accel_endpoint=$accel_enabled
-else
-    accel_endpoint=''
-fi
-
-echo "Using acceleration ( $use_accel ): '$accel_endpoint'"
-
-
-# Check if the bucket with the specified prefix already exists
-check_bucket_exists() {
-    if aws s3api head-bucket --bucket "$1" --region "$region" 2>/dev/null; then
-        echo "Error: Bucket '$1' already exists. Exiting."
-        exit 1
-    fi
-}
-
-# Create the new bucket
-create_bucket() {
-    echo "Creating bucket '$new_bucket'..."
-    if [ "$disable_dryrun" = false ]; then
-        echo "[Dry-run] Skipping bucket creation."
-    else
-
-        echo "Creating bucket '$new_bucket' in region '$region'..."
-        if [ "$region" = "us-east-1" ]; then
-            aws s3api create-bucket --bucket "$new_bucket" --region "$region"
-        else
-            aws s3api create-bucket --bucket "$new_bucket" --region "$region" --create-bucket-configuration LocationConstraint="$region"
-        fi
-        echo "Bucket '$new_bucket' created successfully."
-        aws s3api put-bucket-accelerate-configuration --bucket ${new_bucket} --accelerate-configuration Status=Enabled 
-
-    fi
-}
-
-
-# Check if the bucket already exists
-echo "Checking if bucket '$new_bucket' exists..."
-check_bucket_exists "$new_bucket"
-
-# Create the bucket if it does not exist
-create_bucket
-
-# Compose bucket creation commands
-
-# Core dirs to copy
-ver_info_file="config/day_cluster/daylily_reference_version_$s3_reference_data_version.info"
-echo "$s3_reference_data_version" > $ver_info_file
-cmd_version="aws s3 cp $ver_info_file  s3://${new_bucket}/s3_reference_data_version.info"
-cmd_cluster_boot_config="aws s3 cp s3://${source_bucket}/cluster_boot_config s3://${new_bucket}/cluster_boot_config --recursive  --request-payer requester $accel_endpoint --metadata-directive REPLACE "
-cmd_cached_envs="aws s3 cp s3://${source_bucket}/data/cached_envs s3://${new_bucket}/data/cached_envs --recursive --request-payer requester $accel_endpoint --metadata-directive REPLACE "
-cmd_libs="aws s3 cp s3://${source_bucket}/data/lib s3://${new_bucket}/data/lib --recursive --request-payer requester  $accel_endpoint --metadata-directive REPLACE "
-cmd_tool_specific_resources="aws s3 cp s3://${source_bucket}/data/tool_specific_resources s3://${new_bucket}/data/tool_specific_resources --recursive --request-payer requester $accel_endpoint --metadata-directive REPLACE "
-cmd_budget="aws s3 cp s3://${source_bucket}/data/budget_tags s3://${new_bucket}/data/budget_tags --recursive --request-payer requester $accel_endpoint --metadata-directive REPLACE "
-
-# b37 references
-cmd_b37_ref="aws s3 cp s3://${source_bucket}/data/genomic_data/organism_references/H_sapiens/b37 s3://${new_bucket}/data/genomic_data/organism_references/H_sapiens/b37 --recursive --request-payer requester $accel_endpoint --metadata-directive REPLACE "
-cmd_b37_annotations="aws s3 cp s3://${source_bucket}/data/genomic_data/organism_annotations/H_sapiens/b37 s3://${new_bucket}/data/genomic_data/organism_annotations/H_sapiens/b37 --recursive --request-payer requester $accel_endpoint --metadata-directive REPLACE "
-
-# hg38 references
-cmd_hg38_ref="aws s3 cp s3://${source_bucket}/data/genomic_data/organism_references/H_sapiens/hg38 s3://${new_bucket}/data/genomic_data/organism_references/H_sapiens/hg38 --recursive --request-payer requester $accel_endpoint --metadata-directive REPLACE "
-cmd_hg38_annotations="aws s3 cp s3://${source_bucket}/data/genomic_data/organism_annotations/H_sapiens/hg38 s3://${new_bucket}/data/genomic_data/organism_annotations/H_sapiens/hg38 --recursive --request-payer requester $accel_endpoint --metadata-directive REPLACE "
-
-# Concordance Reads
-cmd_giab_reads="aws s3 cp s3://${source_bucket}/data/genomic_data/organism_reads s3://${new_bucket}/data/genomic_data/organism_reads --recursive --request-payer requester $accel_endpoint --metadata-directive REPLACE "
-
-# CRAMS
-## cmd_giab_crams="aws s3 cp s3://${source_bucket}/data/cram_data s3://${new_bucket}/data/cram_data --recursive --request-payer requester $accel_endpoint --metadata-directive REPLACE "
-
-
-if [ "$disable_dryrun" = false ]; then
-    echo "[Dry-run] Skipping S3 COPY commands, which would be:"
-    echo "$cmd_version"
-    echo "$cmd_cluster_boot_config"
-    echo "$cmd_cached_envs"
-    echo "$cmd_libs"
-    echo "$cmd_tool_specific_resources"
-    echo "$cmd_budget"
-    
-    if [ "$exclude_hg38_refs" = true ]; then
-        echo ">>>> THESE TO BE EXCLUDED"
-        echo "$cmd_hg38_ref"
-        echo "$cmd_hg38_annotations"
-    else
-        echo "THESE WILL BE INCLUDED"
-        echo "$cmd_hg38_ref"
-        echo "$cmd_hg38_annotations"
-    fi
-
-    if [ "$exclude_b37_refs" = true ]; then
-        echo ">>>> THESE TO BE EXCLUDED"
-        echo "$cmd_b37_ref"
-        echo "$cmd_b37_annotations"
-    else
-        echo "THESE WILL BE INCLUDED"
-        echo "$cmd_b37_ref"
-        echo "$cmd_b37_annotations"
-    fi
-
-    if [ "$exclude_giab_reads" = true ]; then
-        echo ">>>> THESE TO BE EXCLUDED"
-        echo "$cmd_giab_reads"
-        #echo "$cmd_giab_crams"
-    else
-        echo "THESE WILL BE INCLUDED"
-        echo "$cmd_giab_reads"
-        #echo "$cmd_giab_crams"
-    fi
-else
-
-    # These are core dirs that need to be copied first
-    echo "Running the following commands serially"
-
-    echo ""
-    echo "NOW RUNNING 1 of 12"
-    echo "...$cmd_version"
-    $cmd_version >> $LOGFILE 2>&1  && echo "success" || echo ">>>FAILED<<< will be fatal"
-    
-
-    echo " "
-    echo "NOW RUNNING 2 of 12"
-    echo "...$cmd_cluster_boot_config"
-    $cmd_cluster_boot_config  >> $LOGFILE 2>&1 && echo "success" || echo ">>>FAILED<<< will be fatal"
-    
-
-    echo "NOW RUNNING 3 of 12"
-    echo "... $cmd_cached_envs"
-    $cmd_cached_envs >> $LOGFILE 2>&1 && echo "success" || echo ">>>FAILED<<< prob ok, but unexpected"
-  
-    echo "NOW RUNNING 4 of 12"
-    echo "...$cmd_libs"
-    $cmd_libs >> $LOGFILE 2>&1  && echo "success" || echo ">>>FAILED<<< will be fatal"
-
-    echo "NOW RUNNING 5 of 12"
-    echo "...$cmd_tool_specific_resources"
-    $cmd_tool_specific_resources  >> $LOGFILE 2>&1  && echo "success" || echo ">>>FAILED<<< will be fatal"
-
-    echo "NOW RUNNING 6 of 12"
-    echo "...$cmd_budget"
-    $cmd_budget  >> $LOGFILE 2>&1  && echo "success" || echo ">>>FAILED<<< will be fatal"
-    
-
-    # Execute commands based on flags
-    if [ "$exclude_hg38_refs" = true ]; then
-        echo "Skipping hg38 references and annotations copy:"
-        echo "$cmd_hg38_ref"
-        echo "$cmd_hg38_annotations"
-    else
-        echo "NOW RUNNING 7 of 12"
-        echo "...$cmd_hg38_ref"
-        $cmd_hg38_ref  >> $LOGFILE 2>&1  && echo "success" || echo ">>>FAILED<<< will be fatal if hg38 is needed" 
-
-        echo "NOW RUNNING 8 of 12"
-        echo "...$cmd_hg38_annotations"
-        $cmd_hg38_annotations >> $LOGFILE 2>&1  && echo "success" || echo ">>>FAILED<<< will be fatal if hg38 is needed" 
-
-    fi
-
-    if [ "$exclude_b37_refs" = true ]; then
-        echo "Skipping b37 references and annotations copy:"
-        echo "$cmd_b37_ref"
-        echo "$cmd_b37_annotations"
-    else
-        echo "NOW RUNNING 9 of 12"
-        echo "...$cmd_b37_ref"
-        $cmd_b37_ref  >> $LOGFILE 2>&1   && echo "success" || echo ">>>FAILED<<< will be fatal if b37 is needed" 
-
-        echo "NOW RUNNING 10 of 12"
-        echo "...$cmd_b37_annotations"
-        $cmd_b37_annotations >> $LOGFILE 2>&1 && echo "success" || echo ">>>FAILED<<< will be fatal if b37 is needed" 
-
-    fi
-
-    if [ "$exclude_giab_reads" = true ]; then
-        echo "Skipping GIAB reads copy:"
-        echo "$cmd_giab_reads"
-
-        echo "Skipping GIAB crams copy:"
-        echo "$cmd_giab_crams"
-
-    else
-        echo "NOW RUNNING 11 of 12"
-        echo "...$cmd_giab_reads"
-        $cmd_giab_reads >> $LOGFILE 2>&1 && echo "success" || echo ">>>FAILED<<< will be fatal if GIAB reads are needed" 
-
-        #echo "NOW RUNNING 12 of 12"
-        #echo "...$cmd_giab_crams"
-        #$cmd_giab_crams >> $LOGFILE 2>&1 && echo "success" || echo ">>>FAILED<<< will be fatal #if GIAB crams are needed"    
-    fi
-
-
-fi
-
-if [ "$disable_dryrun" = false ]; then
-    echo "[Dry-run] Bucket setup for '$new_bucket' would complete successfully. set --disable-dryrun to proceed."
-    exit 0
-else
-    echo "Bucket setup for '$new_bucket' completed successfully."
-fi
-
-
-echo ""
-echo "Cloning of daylily-references-public to '$new_bucket' completed, check the log for more"
-echo "... see $LOGFILE for details"
+echo "Clone command completed. Review $log_file for AWS CLI output if needed."

--- a/bin/daylily-create-ephemeral-cluster
+++ b/bin/daylily-create-ephemeral-cluster
@@ -18,6 +18,19 @@ suppress_pkg_resources_warning() {
     fi
 }
 
+ensure_reference_cli() {
+    if ! command -v daylily-omics-references >/dev/null 2>&1; then
+        cat <<'ERR'
+❌ Error: Required command 'daylily-omics-references' is not available.
+Activate the DAY-EC conda environment or install version 0.1.0 manually with:
+
+    pip install "git+https://github.com/Daylily-Informatics/daylily-omics-references.git@0.1.0"
+
+ERR
+        exit 3
+    fi
+}
+
 sanitize_config_var() {
     local var_name="$1"
     local value="${!var_name}"
@@ -1177,30 +1190,19 @@ fi
 bucket=$(echo "$selected_bucket" )
 set_final_config_value "s3_bucket_name" "$selected_bucket"
 
-
-# Check if the required folders exist in the bucket
-check_s3_folder() {
-    local bucket=$1
-    local folder=$2
-
-    if aws s3 ls "s3://$bucket/$folder/" --profile $AWS_PROFILE > /dev/null 2>&1; then
-        echo "Folder s3://$bucket/$folder/ exists."
-    else
-        echo "❌ Error: Folder s3://$bucket/$folder/ does not exist."
-        exit 1
-    fi
-}
-
-echo "Validating required folders in bucket: $selected_bucket"
-check_s3_folder "$bucket" "data" || exit 3
-check_s3_folder "$bucket" "cluster_boot_config" || exit 3
-
+echo "Validating reference bucket contents for: $selected_bucket"
+ensure_reference_cli
+if daylily-omics-references --profile "$AWS_PROFILE" --region "$region" \
+    verify --bucket "$selected_bucket"; then
+    echo "✅ Reference bucket $selected_bucket passed verification."
+else
+    status=$?
+    echo "❌ Reference bucket verification failed (exit $status). Review the output above for details."
+    exit 3
+fi
 
 bucket_url="s3://$selected_bucket"
 bucket_name=$bucket
-echo "✅ All required folders exist in $bucket_url."
-
-## TODO: add a check to confirim the bucket has the expected s3://%{bucket}/data and s3://%{bucket}/cluster_boot_config folders
 
 echo ""
 

--- a/config/day/daycli.yaml
+++ b/config/day/daycli.yaml
@@ -30,3 +30,4 @@ dependencies:
     - tabulate
     - ruamel.yaml
     - aws-parallelcluster==3.11.1
+    - daylily-omics-references @ git+https://github.com/Daylily-Informatics/daylily-omics-references.git@0.1.0

--- a/docs/quickest_start.md
+++ b/docs/quickest_start.md
@@ -32,6 +32,14 @@ REGION=us-west-2
 
 - This will take ~20min if you remain in `us-west-2`, longer if cross region.
 
+  The script wraps the [`daylily-omics-references`](https://github.com/Daylily-Informatics/daylily-omics-references)
+  CLI (version `0.1.0`). Activate the `DAY-EC` environment or run the CLI directly:
+
+  ```bash
+  daylily-omics-references --profile $AWS_PROFILE --region $REGION \
+    clone --bucket-prefix $BUCKET_PREFIX --version 0.7.131c --execute
+  ```
+
 > your reference bucket will be named **`yocorp-daylily-omics-analysis-us-west-2`**
 
 
@@ -56,6 +64,10 @@ OUT_TSV=./init_daylily_cluster.tsv
 
 ### Create An Ephemeral Cluster
 _this script will check and install a number of prerequsites and attempt to install_
+
+The workflow now verifies your selected reference bucket with the
+`daylily-omics-references` CLI before proceeding, ensuring the expected
+datasets are available.
 
 
 #### Edit `config/daylily_ephemeral_cluster.yaml`


### PR DESCRIPTION
## Summary
- replace the legacy reference bucket shell script with a wrapper around the daylily-omics-references CLI and add the dependency to the DAY-EC environment
- update the cluster creation workflow to verify selected buckets via daylily-omics-references
- refresh documentation to highlight the new CLI usage for cloning and validation

## Testing
- ./bin/create_daylily_omics_analysis_s3.sh -h


------
https://chatgpt.com/codex/tasks/task_e_68d05b16e30c8331a5b3b607a3ae9f36