### PR TITLE
Configure rclone credentials in post install script

### DIFF
--- a/config/day_cluster/post_install_ubuntu_combined.sh
+++ b/config/day_cluster/post_install_ubuntu_combined.sh
@@ -18,6 +18,16 @@ wallet="$4"  # specified in the cluster yaml, wallet
 
 aws configure set region $region
 
+# Configure rclone to use AWS environment credentials in the current region
+mkdir -p "$HOME/.config/rclone"
+cat <<EOF > "$HOME/.config/rclone/rclone.conf"
+[daylily]
+type = s3
+provider = AWS
+env_auth = true
+region = $region
+EOF
+
 # for sentieon
 ulimit -n 16384
 


### PR DESCRIPTION
## Summary
- configure the post-install script to write an rclone configuration that uses the deployment region

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d05cf4b628833196ef9b74ae7896f8