### PR TITLE
Update staging to produce Snakemake config tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -884,11 +884,12 @@ drwxrwxrwx 3 root root 33K Sep 26 08:35 resources
 > Please see the testing section of the [daylily-omics-analysis README](https://github.com/Daylily-Informatics/daylily-omics-analysis).
 ---
 
-## Stage Sample Data & Build an `analysis_manifest.csv`
+## Stage Sample Data & Build `config/samples.tsv` and `config/units.tsv`
 
 The sample staging helper that previously lived in `daylily-omics-analysis` now ships with this repository. Use it to turn an
-`analysis_samples.tsv` file into staged FASTQs under `/fsx/staged_sample_data` and the `analysis_manifest.csv` file that the
-workflows consume. A template TSV is available at [`etc/analysis_samples_template.tsv`](etc/analysis_samples_template.tsv).
+`analysis_samples.tsv` file into staged FASTQs under `/fsx/staged_sample_data` and the Snakemake-style config tables (`samples.tsv`
+and `units.tsv`) that the workflows consume. A template TSV is available at
+[`etc/analysis_samples_template.tsv`](etc/analysis_samples_template.tsv).
 
 ### Run Directly On The Head Node
 
@@ -899,7 +900,7 @@ cd ~/projects/daylily-ephemeral-cluster
 ./bin/daylily-stage-analysis-samples-headnode /path/to/analysis_samples.tsv /fsx/custom_dir
 ```
 
-The helper defaults to `/fsx/staged_sample_data` and writes `analysis_manifest.csv` to that directory after staging.
+The helper defaults to `/fsx/staged_sample_data` and writes `samples.tsv` and `units.tsv` to that directory after staging.
 
 ### Launch Staging From Your Laptop
 
@@ -912,7 +913,7 @@ When values such as the region, cluster name, or PEM file are omitted the script
 
 1. Upload the TSV to the selected head node.
 2. Run `daylily-analysis-samples-to-manifest-new.py` remotely so data are staged into `/fsx/staged_sample_data/<sample_prefix>/`.
-3. Download `analysis_manifest.csv` back next to the local TSV (disable with `--no-download`).
+3. Download `samples.tsv` and `units.tsv` back next to the local TSV (disable with `--no-download`).
 
 This preserves the head node staging behaviour while allowing the process to be initiated during cluster provisioning.
 
@@ -1132,7 +1133,7 @@ The following directories are created and accessible via `/fsx` on the headnode 
 
 - A branch has been started for this work, which is reasonably straightforward. Tasks include:
 -  The AWS parallel cluster slurm snakemake executor, [pcluster-slurm](https://github.com/Daylily-Informatics/snakemake-executor-plugin-pcluster-slurm)  is written, but needs some additional features and to be tested at scale.
--  Migrate from the current `daylily` `analysis_manifest.csv` to the snakemake `v8.*` `config/samples/units` format (which is much cleaner than the current manifest).
+-  ✅ Migrated from the legacy `analysis_manifest.csv` to the Snakemake `v8.*` `config/samples/units` format (which is much cleaner than the original manifest).
 -  The actual workflow files should need very little tweaking.
 
 ## Cromwell & WDL's
@@ -1201,7 +1202,7 @@ ode/rule is distributed to a suitable EC2 spot(or on demand if you prefer) insta
     
 ### [Automated Concordance Analysis Table](http://daylilyinformatics.com:8081/components/daylily_qc_reports/other_reports/giabhcr_concordance_mqc.tsv)
   > Reported faceted by: SNPts, SNPtv, INS>0-<51, DEL>0-51, Indel>0-<51.
-  > Generated when the correct info is set in the analysis_manifest.
+  > Generated when the correct info is set in the config `samples.tsv`/`units.tsv` files.
 
 
 #### [Performance Monitoring Reports]()

--- a/bin/daylily-stage-analysis-samples
+++ b/bin/daylily-stage-analysis-samples
@@ -13,8 +13,9 @@ Options:
   --pem FILE              SSH PEM key for the cluster head node (prompted if omitted)
   --remote-repo PATH      Remote path to the daylily-ephemeral-cluster checkout (default: ~/projects/daylily-ephemeral-cluster)
   --remote-tmp PATH       Remote directory for uploading the TSV (default: /tmp)
-  --output FILE           Local destination for the generated manifest (default: <tsv_dir>/analysis_manifest.csv)
-  --no-download           Skip downloading the manifest back to the local machine
+  --config-dir PATH       Local directory to place downloaded config files (default: <tsv_dir>)
+  --output PATH           Alias for --config-dir (deprecated)
+  --no-download           Skip downloading the config files back to the local machine
   -h, --help              Show this help message and exit
 USAGE
 }
@@ -60,8 +61,8 @@ cluster_name=""
 pem_file=""
 remote_repo="~/projects/daylily-ephemeral-cluster"
 remote_tmp="/tmp"
-download_manifest="true"
-local_manifest=""
+download_config="true"
+local_config_dir=""
 ts_path=""
 
 while [[ $# -gt 0 ]]; do
@@ -94,12 +95,16 @@ while [[ $# -gt 0 ]]; do
             remote_tmp="$2"
             shift 2
             ;;
+        --config-dir)
+            local_config_dir="$2"
+            shift 2
+            ;;
         --output)
-            local_manifest="$2"
+            local_config_dir="$2"
             shift 2
             ;;
         --no-download)
-            download_manifest="false"
+            download_config="false"
             shift
             ;;
         -h|--help)
@@ -207,18 +212,34 @@ remote_repo_remote=${remote_repo/#\~/$'\\$HOME'}
 echo "Running remote staging script..."
 ssh "${ssh_opts[@]}" ubuntu@"$cluster_ip" "cd $remote_repo_remote && AWS_PROFILE='$aws_profile' python3 ./bin/daylily-analysis-samples-to-manifest-new.py '$remote_tsv' '$stage_target'"
 
-echo "Remote staging complete. Manifest located at $stage_target/analysis_manifest.csv"
+echo "Remote staging complete. Config files located at $stage_target/{samples,units}.tsv"
 
-if [[ "$download_manifest" == "true" ]]; then
-    if [[ -z "$local_manifest" ]]; then
-        local_dir=$(cd "$(dirname "$ts_path")" && pwd)
-        local_manifest="$local_dir/analysis_manifest.csv"
-    fi
-    echo "Downloading manifest to $local_manifest..."
-    if ssh "${ssh_opts[@]}" ubuntu@"$cluster_ip" "test -f '$stage_target/analysis_manifest.csv'"; then
-        scp "${ssh_opts[@]}" "ubuntu@${cluster_ip}:${stage_target}/analysis_manifest.csv" "$local_manifest"
+if [[ "$download_config" == "true" ]]; then
+    if [[ -z "$local_config_dir" ]]; then
+        local_config_dir=$(cd "$(dirname "$ts_path")" && pwd)
     else
-        echo "Warning: Manifest not found at $stage_target/analysis_manifest.csv on head node; skipping download." >&2
+        if [[ "$local_config_dir" == *.csv ]]; then
+            echo "Warning: --output now expects a directory; using parent directory of $local_config_dir" >&2
+            local_config_dir=$(python3 -c 'import os,sys; print(os.path.abspath(os.path.dirname(sys.argv[1])))' "$local_config_dir")
+        else
+            local_config_dir=$(python3 -c 'import os,sys; print(os.path.abspath(sys.argv[1]))' "$local_config_dir")
+        fi
+    fi
+
+    mkdir -p "$local_config_dir"
+    local_samples="$local_config_dir/samples.tsv"
+    local_units="$local_config_dir/units.tsv"
+
+    echo "Downloading config files to $local_config_dir..."
+    if ssh "${ssh_opts[@]}" ubuntu@"$cluster_ip" "test -f '$stage_target/samples.tsv' && test -f '$stage_target/units.tsv'"; then
+        scp "${ssh_opts[@]}" "ubuntu@${cluster_ip}:${stage_target}/samples.tsv" "$local_samples"
+        scp "${ssh_opts[@]}" "ubuntu@${cluster_ip}:${stage_target}/units.tsv" "$local_units"
+        echo "Config files downloaded:"
+        echo "  samples -> $local_samples"
+        echo "  units   -> $local_units"
+        echo "Copy them into your workflow checkout (e.g. cp $local_samples config/samples.tsv)."
+    else
+        echo "Warning: Config files not found at $stage_target/{{samples,units}.tsv} on head node; skipping download." >&2
     fi
 fi
 

--- a/bin/daylily-stage-analysis-samples-headnode
+++ b/bin/daylily-stage-analysis-samples-headnode
@@ -5,7 +5,7 @@ usage() {
     cat <<'USAGE'
 Usage: daylily-stage-analysis-samples-headnode <analysis_samples.tsv> [stage_target]
 
-Generate /fsx staging directories and an analysis_manifest.csv from an analysis_samples TSV.
+Generate /fsx staging directories and config/{samples.tsv,units.tsv} from an analysis_samples TSV.
 The optional stage_target defaults to /fsx/staged_sample_data.
 USAGE
 }


### PR DESCRIPTION
## Summary
- generate `config/samples.tsv` and `config/units.tsv` during data staging instead of the legacy manifest
- update the remote staging helper to download the new config files locally and refresh the headnode wrapper usage text
- document the new staging outputs in the README and mark the migration task as complete

## Testing
- python3 -m py_compile bin/daylily-analysis-samples-to-manifest-new.py

------
https://chatgpt.com/codex/tasks/task_e_68d5072704ec83318cdcdd6142665cef