### PR TITLE
Allow lambda adjust policy to target any role

### DIFF
--- a/bin/admin/daylily_ephemeral_cluster_bootstrap_region.sh
+++ b/bin/admin/daylily_ephemeral_cluster_bootstrap_region.sh
@@ -77,11 +77,7 @@ ADJUST_POLICY_DOC=$(cat <<JSON
     {
       "Effect": "Allow",
       "Action": [ "iam:AttachRolePolicy", "iam:DetachRolePolicy" ],
-      "Resource": [
-        "arn:aws:iam::${ACCOUNT_ID}:role/*-RoleHeadNode-*",
-        "arn:aws:iam::${ACCOUNT_ID}:role/*-RoleComputeFleet-*",
-        "arn:aws:iam::${ACCOUNT_ID}:role/*-RoleLoginNode-*"
-      ]
+      "Resource": "*"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- expand the regional bootstrap adjust policy document to grant attach/detach permissions on all roles so ParallelCluster Lambda roles can manage any generated fleet role

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d621afea2c8331b0f960a59b67fe0d